### PR TITLE
Don't write options on every page load.

### DIFF
--- a/inc/base.php
+++ b/inc/base.php
@@ -1,7 +1,7 @@
 <?php
 
 function mm_setup() {
-	if ( ! get_option( 'mm_master_aff' ) ) {
+	if ( '' === get_option( 'mm_master_aff' ) || (defined( 'MMAFF' ) && MMAFF != get_option( 'mm_master_aff' ) ) ) {
 		update_option( 'mm_master_aff', ( defined( 'MMAFF' ) ? MMAFF : '' ) );
 	}
 	if ( ! get_option( 'mm_install_date' ) ) {


### PR DESCRIPTION
If the option has already been set to an empty string, and the value
doesn't differ from the `MMAFF` constant don't update the option.