### PR TITLE
Enable JetPack SSO by default

### DIFF
--- a/inc/jetpack.php
+++ b/inc/jetpack.php
@@ -2,6 +2,7 @@
 // Add Photon to the list of default modules activated when Jetpack is linked to WP.
 function mm_customize_jetpack_default_modules( $modules ) {
 	$modules[] = 'photon';
+	$modules[] = 'sso';
 	return array_unique( $modules );
 }
 add_filter( 'jetpack_get_default_modules', 'mm_customize_jetpack_default_modules' );


### PR DESCRIPTION
Enable JetPack Single Sign On module by default. Tested on Bluehost box. Resolves EP9-31