### PR TITLE
Set REMOTE_ADDR when using CDN

### DIFF
--- a/inc/base.php
+++ b/inc/base.php
@@ -7,29 +7,30 @@ function mm_setup() {
 	if ( ! get_option( 'mm_install_date' ) ) {
 		update_option( 'mm_install_date', date( 'M d, Y' ) );
 		$event = array(
-			't'		=> 'event',
-			'ec'	=> 'plugin_status',
-			'ea'	=> 'installed',
-			'el'	=> 'Install date: ' . get_option( 'mm_install_date', date( 'M d, Y' ) ),
-			'keep'	=> false,
+			't'    => 'event',
+			'ec'   => 'plugin_status',
+			'ea'   => 'installed',
+			'el'   => 'Install date: ' . get_option( 'mm_install_date', date( 'M d, Y' ) ),
+			'keep' => false,
 		);
 		$events = get_option( 'mm_cron', array() );
 		$events['hourly'][ $event['ea'] ] = $event;
 		update_option( 'mm_cron', $events );
 	}
 }
+
 add_action( 'admin_init', 'mm_setup' );
 
 function mm_api( $args = array(), $query = array() ) {
 	$api_url = 'http://api.mojomarketplace.com/api/v1/';
 	$default_args = array(
-		'mojo-platform' 	=> 'wordpress',
-		'mojo-type' 		=> 'themes',
-		'mojo-items' 		=> 'recent',
+		'mojo-platform' => 'wordpress',
+		'mojo-type'     => 'themes',
+		'mojo-items'    => 'recent',
 	);
 	$default_query = array(
-		'count'		=> 30,
-		'seller'	=> '',
+		'count'  => 30,
+		'seller' => '',
 	);
 	$args = wp_parse_args( $args, $default_args );
 	$query = wp_parse_args( $query, $default_query );
@@ -50,16 +51,17 @@ function mm_api_cache( $api_url ) {
 			set_transient( 'mm_api_calls', $transient, DAY_IN_SECONDS );
 		}
 	}
+
 	return $transient[ $key ];
 }
 
 function mm_build_link( $url, $args = array() ) {
 	$defaults = array(
-		'utm_source'	=> 'mojo_wp_plugin', //this should always be mojo_wp_plugin
-		'utm_campaign'	=> 'mojo_wp_plugin',
-		'utm_medium'	=> 'plugin_admin', //(plugin_admin, plugin_widget, plugin_shortcode)
-		'utm_content'	=> '', //specific location
-		'r'				=> get_option( 'mm_master_aff' ),
+		'utm_source'   => 'mojo_wp_plugin', //this should always be mojo_wp_plugin
+		'utm_campaign' => 'mojo_wp_plugin',
+		'utm_medium'   => 'plugin_admin', //(plugin_admin, plugin_widget, plugin_shortcode)
+		'utm_content'  => '', //specific location
+		'r'            => get_option( 'mm_master_aff' ),
 	);
 	$args = wp_parse_args( array_filter( $args ), array_filter( $defaults ) );
 
@@ -85,6 +87,7 @@ function mm_clear_api_calls() {
 		delete_transient( 'mojo_api_calls' );
 	}
 }
+
 add_action( 'wp_login', 'mm_clear_api_calls' );
 add_action( 'pre_current_active_plugins', 'mm_clear_api_calls' );
 
@@ -105,19 +108,22 @@ function mm_cron() {
 		wp_schedule_event( time(), 'hourly', 'mm_cron_hourly' );
 	}
 }
+
 add_action( 'admin_init', 'mm_cron' );
 
 function mm_cron_schedules( $schedules ) {
 	$schedules['weekly'] = array(
 		'interval' => WEEK_IN_SECONDS,
-		'display' => __( 'Once Weekly' ),
+		'display'  => __( 'Once Weekly' ),
 	);
 	$schedules['monthly'] = array(
 		'interval' => 4 * WEEK_IN_SECONDS,
-		'display' => __( 'Once a month' ),
+		'display'  => __( 'Once a month' ),
 	);
+
 	return $schedules;
 }
+
 add_filter( 'cron_schedules', 'mm_cron_schedules' );
 
 function mm_all_api_calls() {
@@ -139,6 +145,7 @@ function mm_all_api_calls() {
 	}
 	die;
 }
+
 add_action( 'wp_ajax_all-api-calls', 'mm_all_api_calls' );
 
 function mm_preload_api_calls() {
@@ -149,10 +156,12 @@ function mm_preload_api_calls() {
 	$url = $admin_ajax . '?' . http_build_query( $params );
 	$res = wp_remote_get( $url, array( 'blocking' => false, 'timeout' => 0.1, 'cookies' => $_COOKIE ) );
 }
+
 add_action( 'admin_footer-index.php', 'mm_preload_api_calls', 99 );
 
 function mm_slug_to_title( $slug ) {
 	$slug = ucwords( str_replace( '-', ' ', $slug ) );
+
 	//fun fact: capital_P_dangit( 'Wordpress' ) does not return 'WordPress'
 	return str_replace( 'Wordpress', 'WordPress', $slug );
 }
@@ -165,9 +174,11 @@ function mm_require( $original ) {
 	$file = apply_filters( 'mm_require_file', $original );
 	if ( file_exists( $file ) ) {
 		require( $file );
+
 		return $file;
 	} elseif ( file_exists( $original ) ) {
 		require( $original );
+
 		return $original;
 	} else {
 		return false;
@@ -180,75 +191,84 @@ function mm_minify( $content ) {
 	$content = str_replace( "\t", '', $content );
 	$content = str_replace( '  ', ' ', $content );
 	$content = trim( $content );
+
 	return $content;
 }
 
 function mm_safe_hosts( $hosts ) {
 	$hosts[] = 'mojomarketplace.com';
+
 	return $hosts;
 }
+
 add_filter( 'allowed_redirect_hosts', 'mm_safe_hosts' );
 
 function mm_better_news_feed( $feed ) {
 	return 'http://feeds.feedburner.com/wp-pipes';
 }
+
 add_filter( 'dashboard_secondary_feed', 'mm_better_news_feed' );
 add_filter( 'dashboard_secondary_link', 'mm_better_news_feed' );
 
 function mm_adjust_feed_transient_lifetime( $lifetime ) {
 	return 3 * HOUR_IN_SECONDS;
 }
+
 add_filter( 'wp_feed_cache_transient_lifetime', 'mm_adjust_feed_transient_lifetime' );
 
 function mm_stars( $rating = 4.5, $sales = 0 ) {
-	if ( ! is_numeric( $rating ) || 0 == $rating ) { return; }
+	if ( ! is_numeric( $rating ) || 0 == $rating ) {
+		return;
+	}
 	?>
-	<div class="star-rating">
-		<ul class="list-unstyled list-inline">
+    <div class="star-rating">
+        <ul class="list-unstyled list-inline">
 			<?php
 			$rating_half = round( $rating * 2 ) / 2;
-			$stars = ( 0 == $rating_half) ? 5 : 0;
-			for ( $i = 0; $i < floor( $rating_half ); $i++ ) {
-				$stars++;
+			$stars = ( 0 == $rating_half ) ? 5 : 0;
+			for ( $i = 0; $i < floor( $rating_half ); $i ++ ) {
+				$stars ++;
 				?>
-				<li><a href="#"><span class="dashicons dashicons-star-filled"></span></a></li>
+                <li><a href="#"><span class="dashicons dashicons-star-filled"></span></a></li>
 				<?php
 			}
 			if ( false !== strpos( $rating_half, '.' ) ) {
-				$stars++;
+				$stars ++;
 				?>
-				<li><a href="#"><span class="dashicons dashicons-star-half"></span></a></li>
+                <li><a href="#"><span class="dashicons dashicons-star-half"></span></a></li>
 				<?php
 			}
 			if ( $stars < 5 ) {
 				$empty_stars = 5 - $stars;
-				for ( $i = 0; $i < $empty_stars; $i++ ) {
+				for ( $i = 0; $i < $empty_stars; $i ++ ) {
 					?>
-					<li><a href="#"><span class="dashicons dashicons-star-empty"></span></a></li>
+                    <li><a href="#"><span class="dashicons dashicons-star-empty"></span></a></li>
 					<?php
 				}
 			}
 			?>
-		</ul>
-		<span class="rating-label"><span class="count"><?php echo $rating_half; ?></span> Stars
-		<?php
-		if ( 0 !== $sales ) {
-			?>
-			<span class="sales-count">(<?php echo number_format( $sales ); ?> Sales)</span>
+        </ul>
+        <span class="rating-label"><span class="count"><?php echo $rating_half; ?></span> Stars
 			<?php
-		}
-		?>
+			if ( 0 !== $sales ) {
+				?>
+                <span class="sales-count">(<?php echo number_format( $sales ); ?> Sales)</span>
+				<?php
+			}
+			?>
 		</span>
-	</div>
+    </div>
 	<?php
 }
 
 function mm_pagination( $page = 1, $total_pages = 1 ) {
-	if ( 1 == $total_pages ) { return; }
+	if ( 1 == $total_pages ) {
+		return;
+	}
 	?>
-	<div class="alignright">
-		<nav class="pagination">
-			<ul class="group">
+    <div class="alignright">
+        <nav class="pagination">
+            <ul class="group">
 				<?php
 				$pagination_start = $page - 5;
 				$pagination_end = $page + 5;
@@ -266,45 +286,49 @@ function mm_pagination( $page = 1, $total_pages = 1 ) {
 					$pagination_end = $total_pages;
 				}
 				?>
-				<li class="prev">
-					<a href="<?php echo esc_url( add_query_arg( array( 'paged' => $page - 1 ) ) ); ?>"><span class="dashicons dashicons-arrow-left"></span></a>
-				</li>
+                <li class="prev">
+                    <a href="<?php echo esc_url( add_query_arg( array( 'paged' => $page - 1 ) ) ); ?>"><span
+                                class="dashicons dashicons-arrow-left"></span></a>
+                </li>
 				<?php
-				for ( $i = $pagination_start;  $i <= $pagination_end;  $i++ ) {
+				for ( $i = $pagination_start; $i <= $pagination_end; $i ++ ) {
 					?>
-					<li<?php if ( $i == $page ) { echo " class='active'";}?> >
-						<a href="<?php echo esc_url( add_query_arg( array( 'paged' => $i ) ) ); ?>"><?php echo $i; ?></a>
-					</li>
+                    <li<?php if ( $i == $page ) {
+						echo " class='active'";
+					} ?> >
+                        <a href="<?php echo esc_url( add_query_arg( array( 'paged' => $i ) ) ); ?>"><?php echo $i; ?></a>
+                    </li>
 					<?php
 				}
 				?>
-				<li class="next">
+                <li class="next">
 					<?php
-					$next_num = ( $page + 1 >= $total_pages ) ? $total_pages : $page + 1 ;
+					$next_num = ( $page + 1 >= $total_pages ) ? $total_pages : $page + 1;
 					?>
-					<a rel="next" href="<?php echo esc_url( add_query_arg( array( 'paged' => $next_num ) ) ); ?>">
-						<span class="dashicons dashicons-arrow-right"></span>
-					</a>
-				</li>
-			</ul>
-		</nav>
-	</div>
+                    <a rel="next" href="<?php echo esc_url( add_query_arg( array( 'paged' => $next_num ) ) ); ?>">
+                        <span class="dashicons dashicons-arrow-right"></span>
+                    </a>
+                </li>
+            </ul>
+        </nav>
+    </div>
 	<?php
 }
 
 function mm_loader() {
 	if ( isset( $_GET['page'] ) && false !== strpos( $_GET['page'], 'mojo-' ) && mm_brand() == 'bluehost' ) {
 		?>
-		<script type="text/javascript">
-		jQuery( document ).ready( function( $ ) {
-			setTimeout( function() {
-				$( '.bluehost-loader' ).fadeOut( 'slow' );
-			}, 2000 );
-		} );
-		</script>
+        <script type="text/javascript">
+            jQuery(document).ready(function ($) {
+                setTimeout(function () {
+                    $('.bluehost-loader').fadeOut('slow');
+                }, 2000);
+            });
+        </script>
 		<?php
 	}
 }
+
 add_action( 'admin_footer', 'mm_loader' );
 
 function mm_truncate_name( $name, $length = 14 ) {
@@ -313,8 +337,10 @@ function mm_truncate_name( $name, $length = 14 ) {
 	$name = explode( ' ', $name );
 	$truncated_name = '';
 	if ( count( $name ) !== 1 ) {
-		for ( $i = 0; $i < count( $name ) - 1; $i++ ) {
-			if ( in_array( $name[ $i ] , array( 'A', 'An' ) ) ) { continue; }
+		for ( $i = 0; $i < count( $name ) - 1; $i ++ ) {
+			if ( in_array( $name[ $i ], array( 'A', 'An' ) ) ) {
+				continue;
+			}
 			$truncated_name .= ' ' . $name[ $i ];
 		}
 	} else {
@@ -322,6 +348,7 @@ function mm_truncate_name( $name, $length = 14 ) {
 	}
 	$truncated_name = trim( $truncated_name, '–' );
 	$truncated_name = trim( $truncated_name );
+
 	return $truncated_name;
 }
 
@@ -335,6 +362,7 @@ function mm_site_bin2hex() {
 	}
 
 	$path_hash = bin2hex( $path );
+
 	return $path_hash;
 }
 
@@ -358,6 +386,7 @@ function _mm_login() {
 		}
 	}
 }
+
 add_action( 'admin_init', '_mm_login', 5 );
 
 /**

--- a/inc/base.php
+++ b/inc/base.php
@@ -359,3 +359,37 @@ function _mm_login() {
 	}
 }
 add_action( 'admin_init', '_mm_login', 5 );
+
+/**
+ * Get the client IP address.
+ *
+ * @return string
+ */
+function mm_get_client_ip() {
+
+	// Default to REMOTE_ADDR
+	$ip = $_SERVER['REMOTE_ADDR'];
+
+	$proxy_headers = array(
+		'HTTP_CF_CONNECTING_IP', // CloudFlare
+		'HTTP_FASTLY_CLIENT_IP', // Fastly
+		'HTTP_INCAP_CLIENT_IP', // Incapsula
+		'HTTP_TRUE_CLIENT_IP', // CloudFlare Enterprise
+		'HTTP_X_FORWARDED_FOR', // Any proxy
+		'HTTP_X_SUCURI_CLIENTIP', // Sucuri
+	);
+
+	// Check for alternate headers indicating a forwarded IP address
+	foreach ( $proxy_headers as $proxy_header ) {
+		if ( ! empty( $_SERVER[ $proxy_header ] ) ) {
+			$forwarded_ips = explode( ',', $_SERVER[ $proxy_header ] );
+			$forwarded_ip = array_shift( $forwarded_ips );
+			if ( $forwarded_ip ) {
+				$ip = $forwarded_ip;
+				break;
+			}
+		}
+	}
+
+	return $ip;
+}

--- a/mojo-marketplace.php
+++ b/mojo-marketplace.php
@@ -28,6 +28,9 @@ if ( version_compare( phpversion(), 5.3, '<' ) ) {
 }
 
 require_once( MM_BASE_DIR . 'inc/base.php' );
+
+$_SERVER['REMOTE_ADDR'] = mm_get_client_ip();
+
 require_once( MM_BASE_DIR . 'inc/checkout.php' );
 require_once( MM_BASE_DIR . 'inc/menu.php' );
 require_once( MM_BASE_DIR . 'inc/shortcode-generator.php' );


### PR DESCRIPTION
It looks like we may not have an option and will have to override the REMOTE_ADDR server var to ensure that JetPack Protect gets the correct client IP. 

The reason being that JetPack Protect makes an API call to their own server and the response gets stored in an option in the database called "trusted_ip_header". That option contains the name of the trusted header, which appears to be HTTP_X_REAL_IP, but can potentially be different depending on the API response. 

I assume that JetPack Protect does this because they do need to update the logic and change the trusted header from time to time. As a result, we can't necessarily rely on explicitly setting HTTP_X_REAL_IP when JetPack Protect may look at a different header depending on the circumstances. **If we can validate with JetPack directly that this header does NOT change, then it would be best to override this header instead.**

_Side note: This PR contains includes the reformatting of the base.php file. The code that actually changed is the code block at the bottom of the base.php file and the one line added to the mojo-marketplace.php file._