### PR TITLE
Remove 'CDN' panel

### DIFF
--- a/pages/mojo-home.php
+++ b/pages/mojo-home.php
@@ -186,7 +186,7 @@ if ( $is_bluerock ) {
 			<?php } ?>
 			<?php if ( 'bluehost' == mm_brand() ) { ?>
 			<h2 id="performance">Performance</h2>
-			<div class="col-xs-12 col-sm-4">
+			<div class="col-xs-12 col-sm-6">
 				<div class="panel panel-default panel-body text-center performance-card">
 					<div>
 					<span class="dashicons dashicons-performance"></span>
@@ -198,19 +198,7 @@ if ( $is_bluerock ) {
 					</div>
 				</div>
 			</div>
-			<div class="col-xs-12 col-sm-4">
-				<div class="panel panel-default panel-body text-center performance-card">
-					<div>
-					<span class="dashicons dashicons-cloud"></span>
-						<h2>CDN</h2>
-						<p>A Content Delivery Network (CDN) will distribute your website around the globe for global retrieval.</p>
-						<div class="col-xs-12 col-sm-12">
-							<a class="btn btn-primary btn-md" href="" target="_blank">Manage</a>
-						</div>
-					</div>
-				</div>
-			</div>
-			<div class="col-xs-12 col-sm-4">
+			<div class="col-xs-12 col-sm-6">
 				<div class="panel panel-default panel-body text-center performance-card">
 					<div>
 					<div><span class="dashicons dashicons-visibility"></span></div>


### PR DESCRIPTION
Remove the middle 'CDN' panel from the 'Performance' section of the Bluehost plugin dashboard.