### PR TITLE
repair php warning from accessing nonexistent key

### DIFF
--- a/inc/cli-init.php
+++ b/inc/cli-init.php
@@ -220,7 +220,7 @@ class EIG_WP_CLI_Loader {
 
 			if ( ! empty( $cmd['shortdesc'] ) ) {
 				$args['shortdesc'] = $cmd['shortdesc'];
-				$args['synopsis']  = $cmd['synopsis'];
+				$args['synopsis']  = $cmd['shortdesc'];
 			}
 
 			if ( ! empty( $cmd['longdesc'] ) ) {


### PR DESCRIPTION
Data model can be found at top of file.