### PR TITLE
🐛 Remove synopsis arg spitting warning

### DIFF
--- a/inc/cli-init.php
+++ b/inc/cli-init.php
@@ -220,7 +220,6 @@ class EIG_WP_CLI_Loader {
 
 			if ( ! empty( $cmd['shortdesc'] ) ) {
 				$args['shortdesc'] = $cmd['shortdesc'];
-				$args['synopsis']  = $cmd['shortdesc'];
 			}
 
 			if ( ! empty( $cmd['longdesc'] ) ) {


### PR DESCRIPTION
Removes Warning for `synopsis` which shouldn't be receiving the description string being sent.