### PR TITLE
Add last login to user meta and as an option.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
   },
   "extra": {
     "phpcs-config": {
+      "colors": 1,
       "default_standard": "Bluehost",
       "testVersion": "5.2-"
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2d3a5d84d734e4f499102c40489e69ec",
+    "content-hash": "fd771b25eb3f1017181c858ee717c6a5",
     "packages": [
         {
             "name": "automattic/jetpack-onboarding",

--- a/inc/track-last-login.php
+++ b/inc/track-last-login.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * File handles tracking the last time a user logged in.
+ *
+ * @package Mojo Marketplace
+ */
+
+add_action( 'wp_login', 'endurance_set_last_login', 10, 2 );
+
+/**
+ * Sets the time in ISO8601 format for the last time a user logged in.
+ *
+ * @param string   $username Current user login name
+ * @param \WP_User $user Current user object
+ */
+function endurance_set_last_login( $username, WP_User $user ) {
+
+	// Store last login for current user
+	update_user_meta( $user->ID, 'eig_last_login', date( 'c' ) );
+
+	// Store last login for entire site for any user that can impact content.
+	if ( $user->has_cap( 'edit_posts' ) ) {
+		update_option( 'eig_last_site_login', date( 'c' ) );
+	}
+
+}

--- a/mojo-marketplace.php
+++ b/mojo-marketplace.php
@@ -43,6 +43,7 @@ require_once( MM_BASE_DIR . 'inc/coming-soon.php' );
 require_once( MM_BASE_DIR . 'inc/tests.php' );
 require_once( MM_BASE_DIR . 'inc/performance.php' );
 require_once( MM_BASE_DIR . 'inc/partners.php' );
+require_once MM_BASE_DIR . 'inc/track-last-login.php';
 mm_require( MM_BASE_DIR . 'inc/branding.php' );
 if ( mm_jetpack_bluehost_only() ) {
 	$onboard_time = strtotime( get_option( 'mm_install_date', 0 ) ) + DAY_IN_SECONDS * 90;

--- a/mojo-marketplace.php
+++ b/mojo-marketplace.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * Plugin Name: MOJO Marketplace
  * Description: This plugin adds shortcodes, widgets, and themes to your WordPress site.
  * Version: 1.4.2
@@ -8,6 +7,8 @@
  * Author URI: http://mikehansen.me?utm_campaign=plugin&utm_source=mojo_wp_plugin
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * @package Mojo Marketplace
  */
 
 // Do not access file directly!
@@ -22,28 +23,29 @@ define( 'MM_ASSETS_URL', 'https://www.mojomarketplace.com/mojo-plugin-assets/' )
 
 // Composer autoloader
 if ( version_compare( phpversion(), 5.3, '<' ) ) {
-	require __DIR__ . '/vendor/autoload_52.php';
+	require dirname( __FILE__ ) . '/vendor/autoload_52.php';
 } else {
-	require __DIR__ . '/vendor/autoload.php';
+	require dirname( __FILE__ ) . '/vendor/autoload.php';
 }
 
-require_once( MM_BASE_DIR . 'inc/base.php' );
-require_once( MM_BASE_DIR . 'inc/checkout.php' );
-require_once( MM_BASE_DIR . 'inc/menu.php' );
-require_once( MM_BASE_DIR . 'inc/shortcode-generator.php' );
-require_once( MM_BASE_DIR . 'inc/mojo-themes.php' );
-require_once( MM_BASE_DIR . 'inc/styles.php' );
-require_once( MM_BASE_DIR . 'inc/plugin-search.php' );
-require_once( MM_BASE_DIR . 'inc/jetpack.php' );
-require_once( MM_BASE_DIR . 'inc/user-experience-tracking.php' );
-require_once( MM_BASE_DIR . 'inc/notifications.php' );
-require_once( MM_BASE_DIR . 'inc/staging.php' );
-require_once( MM_BASE_DIR . 'inc/updates.php' );
-require_once( MM_BASE_DIR . 'inc/coming-soon.php' );
-require_once( MM_BASE_DIR . 'inc/tests.php' );
-require_once( MM_BASE_DIR . 'inc/performance.php' );
-require_once( MM_BASE_DIR . 'inc/partners.php' );
+require_once MM_BASE_DIR . 'inc/base.php';
+require_once MM_BASE_DIR . 'inc/checkout.php';
+require_once MM_BASE_DIR . 'inc/menu.php';
+require_once MM_BASE_DIR . 'inc/shortcode-generator.php';
+require_once MM_BASE_DIR . 'inc/mojo-themes.php';
+require_once MM_BASE_DIR . 'inc/styles.php';
+require_once MM_BASE_DIR . 'inc/plugin-search.php';
+require_once MM_BASE_DIR . 'inc/jetpack.php';
+require_once MM_BASE_DIR . 'inc/user-experience-tracking.php';
+require_once MM_BASE_DIR . 'inc/notifications.php';
+require_once MM_BASE_DIR . 'inc/staging.php';
+require_once MM_BASE_DIR . 'inc/updates.php';
+require_once MM_BASE_DIR . 'inc/coming-soon.php';
+require_once MM_BASE_DIR . 'inc/tests.php';
 require_once MM_BASE_DIR . 'inc/track-last-login.php';
+require_once MM_BASE_DIR . 'inc/performance.php';
+require_once MM_BASE_DIR . 'inc/partners.php';
+
 mm_require( MM_BASE_DIR . 'inc/branding.php' );
 if ( mm_jetpack_bluehost_only() ) {
 	$onboard_time = strtotime( get_option( 'mm_install_date', 0 ) ) + DAY_IN_SECONDS * 90;


### PR DESCRIPTION
Resolves JIRA issue EP9-92. Option name is `eig_last_site_login`. User meta key is `eig_last_login`. Date/time is in ISO-8601 format. Option is only set if a user can edit content (i.e. has the `edit_posts` capability). 

Also updated PHPCS output to be in color. Corrected PHPCS issues in main plugin file.