### PR TITLE
mitigate fatal in installer script from sso command

### DIFF
--- a/inc/cli/sso.php
+++ b/inc/cli/sso.php
@@ -10,22 +10,22 @@ class EIG_WP_CLI_SSO extends EIG_WP_CLI_Command {
 	/**
 	 * @var string - Stored transient key used for SSO.
 	 */
-	private static $transient_slug = 'sso_token';
+	static $transient_slug = 'sso_token';
 
 	/**
 	 * @var string - Nonce validation key.
 	 */
-	private static $nonce_slug = 'mojo-sso';
+	static $nonce_slug = 'mojo-sso';
 
 	/**
 	 * @var string - Nonce action key.
 	 */
-	private static $nonce_action = 'sso-check';
+	static $nonce_action = 'sso-check';
 
 	/**
 	 * @var int Time for nonce token to be valid.
 	 */
-	protected $expiry_min = 3;
+	public $expiry_min = 3;
 
 	/**
 	 * @var string - Cryptographic salt.

--- a/inc/cli/sso.php
+++ b/inc/cli/sso.php
@@ -10,17 +10,17 @@ class EIG_WP_CLI_SSO extends EIG_WP_CLI_Command {
 	/**
 	 * @var string - Stored transient key used for SSO.
 	 */
-	static $transient_slug = 'sso_token';
+	public static $transient_slug = 'sso_token';
 
 	/**
 	 * @var string - Nonce validation key.
 	 */
-	static $nonce_slug = 'mojo-sso';
+	public static $nonce_slug = 'mojo-sso';
 
 	/**
 	 * @var string - Nonce action key.
 	 */
-	static $nonce_action = 'sso-check';
+	public static $nonce_action = 'sso-check';
 
 	/**
 	 * @var int Time for nonce token to be valid.


### PR DESCRIPTION
As this repo is FOSS, little value in protecting the slugs/action strings. if issue continues with remaining `protected` variables we should explore a different approach