### PR TITLE
Remove cache level 4 setting from performance tab

### DIFF
--- a/pages/mojo-performance.php
+++ b/pages/mojo-performance.php
@@ -59,7 +59,6 @@ $php_edge_settings = get_option( 'mm_php_edge_settings', '56' );
 									1 => 'Assets Only',
 									2 => 'Normal',
 									3 => 'Advanced',
-									4 => 'Aggressive',
 								);
 								foreach ( $levels as $level => $label ) {
 									echo '<label class="top-4 radio-inline"><input type="radio" name="cache_level" value="' . $level . '" ' . checked( $level, $cache_level, false ) . '/> ' . $label . '</label><br/>';


### PR DESCRIPTION
This simplifies the caching options to remove level 4.

Options become:

0 - Off
1 - Assets only for 1 hour
2 - Assets 6 hours and pages 5 minutes
3 - Assets 1 week and pages 5 minutes