### PR TITLE
Add the GitHub archive installer as a dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
     "bluehost/endurance-wp-module-loader": "^1.0",
     "bluehost/endurance-wp-module-spam-prevention": "^1.0",
     "bluehost/endurance-wp-module-sso": "^1.0",
-    "bluehost/endurance-wp-plugin-updater": "^1.0"
+    "bluehost/endurance-wp-plugin-updater": "^1.0",
+    "wpscholar/github-archive-installer": "^1.1"
   },
   "require-dev": {
     "bluehost/wp-php-standards": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cf2f69aa12d9b365172f040c997497a3",
+    "content-hash": "b04b323ed5b16cc4de6c68a5e64a6413",
     "packages": [
         {
             "name": "bluehost/endurance-wp-module-business-reviews",
@@ -336,6 +336,45 @@
                 "psr"
             ],
             "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "wpscholar/github-archive-installer",
+            "version": "1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wpscholar/github-archive-installer.git",
+                "reference": "c3e325f345e2ca3e3a110294e8914a747b16150d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wpscholar/github-archive-installer/zipball/c3e325f345e2ca3e3a110294e8914a747b16150d",
+                "reference": "c3e325f345e2ca3e3a110294e8914a747b16150d",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1 || ^2.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "wpscholar\\Composer\\GithubArchiveInstaller"
+            },
+            "autoload": {
+                "psr-4": {
+                    "wpscholar\\Composer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Micah Wood",
+                    "email": "micah@wpscholar.com"
+                }
+            ],
+            "description": "A custom Composer installer that will install a dependency from a GitHub release archive .zip file when installing from distribution.",
+            "time": "2020-04-24T14:36:31+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
Add the GitHub archive installer as a dependency so `composer install --prefer-dist` will use the custom `.zip` file from our release assets.