### PR TITLE
WordPress 5.5 Core auto-update support

### DIFF
--- a/inc/updates.php
+++ b/inc/updates.php
@@ -115,7 +115,7 @@ function mm_auto_update_configure() {
 	$settings = array(
 		'allow_major_auto_core_updates' => get_option( 'allow_major_auto_core_updates', true ),
 		'allow_minor_auto_core_updates' => get_option( 'allow_minor_auto_core_updates', true ),
-		'auto_update_plugin'            => get_option( 'auto_update_plugin', true ),
+//		'auto_update_plugin'            => get_option( 'auto_update_plugin', true ),
 		'auto_update_theme'             => get_option( 'auto_update_theme', true ),
 		'auto_update_translation'       => get_option( 'auto_update_translation', true ),
 	);
@@ -238,3 +238,27 @@ function mm_plugin_theme_installed( $wp_upgrader, $hook_extra ) {
 	}
 }
 add_action( 'upgrader_process_complete', 'mm_plugin_theme_installed', 10, 2 );
+
+/**
+ * Checks for manual changes by the user to the auto-update settings.
+ *
+ * If auto-updates for an individual plugin or theme are disabled, then the on/off
+ * setting can't always adjust accordingly.
+ *
+ * @param string $type The type of auto-update to check. Defaults to 'plugin'.
+ * @return bool If there are manual changes to auto-updates for the passed type.
+ *              Returns true if there are user changes, false if there are not.
+ */
+function mm_has_user_changes_auto_updates( $type = 'plugin' ) {
+	if ( 'theme' === $type ) {
+		$auto_updating_themes = sort( get_site_option( "auto_update_themes", array() ) );
+		$installed_themes = sort( array_keys( wp_get_themes() ) );
+
+		return $auto_updating_themes !== $installed_themes;
+	}
+
+	$installed_plugins = sort( array_keys( get_plugins() ) );
+	$auto_updating_plugins = sort( get_site_option( "auto_update_plugins", array() ) );
+
+	return $auto_updating_plugins !== $installed_plugins;
+}

--- a/inc/updates.php
+++ b/inc/updates.php
@@ -26,8 +26,8 @@ function mm_auto_update_callback( $args ) {
 			'auto_update_translation'       => 'true',
 		);
 		$value    = get_option( $args['field'], $defaults[ $args['field'] ] );
-		echo __( 'On', 'mojo-marketplace-wp-plugin' ) . " <input type='radio' name='" . $args['field'] . "' value='true'" . checked( $value, 'true', false ) . ' />';
-		echo __( 'Off', 'mojo-marketplace-wp-plugin' ) . " <input type='radio' name='" . $args['field'] . "' value='false'" . checked( $value, 'false', false ) . ' />';
+		echo __( 'On', 'mojo-marketplace-wp-plugin' ) . " <input type='radio' name='" . esc_attr( $args['field'] ) . "' value='true'" . checked( $value, 'true', false ) . ' />';
+		echo __( 'Off', 'mojo-marketplace-wp-plugin' ) . " <input type='radio' name='" . esc_attr( $args['field'] ) . "' value='false'" . checked( $value, 'false', false ) . ' />';
 	}
 }
 

--- a/inc/updates.php
+++ b/inc/updates.php
@@ -23,7 +23,6 @@ function mm_auto_update_callback( $args ) {
 			'allow_minor_auto_core_updates' => 'true',
 			'auto_update_plugin'            => 'true',
 			'auto_update_theme'             => 'true',
-			'auto_update_translation'       => 'true',
 		);
 		$value    = get_option( $args['field'], $defaults[ $args['field'] ] );
 		echo __( 'On', 'mojo-marketplace-wp-plugin' ) . " <input type='radio' name='" . esc_attr( $args['field'] ) . "' value='true'" . checked( $value, 'true', false ) . ' />';
@@ -97,16 +96,6 @@ function mm_auto_update_register_settings() {
 		array( 'field' => 'auto_update_plugin' )
 	);
 	register_setting( 'general', 'auto_update_plugin' );
-
-	add_settings_field(
-		'auto_update_translation',
-		__( 'Translations', 'mojo-marketplace-wp-plugin' ),
-		'mm_auto_update_callback',
-		$section_hook,
-		$section_name,
-		array( 'field' => 'auto_update_translation' )
-	);
-	register_setting( 'general', 'auto_update_translation' );
 }
 add_action( 'admin_init', 'mm_auto_update_register_settings' );
 
@@ -118,7 +107,6 @@ function mm_auto_update_configure() {
 		'allow_minor_auto_core_updates' => get_option( 'allow_minor_auto_core_updates', true ),
 		'auto_update_plugin'            => get_option( 'auto_update_plugin', true ),
 		'auto_update_theme'             => get_option( 'auto_update_theme', true ),
-		'auto_update_translation'       => get_option( 'auto_update_translation', true ),
 	);
 
 	// only change setting if the updater is not disabled

--- a/inc/updates.php
+++ b/inc/updates.php
@@ -1,8 +1,17 @@
 <?php
-/*
-	Auto Update Major on New Installs and default for all other with a setting section to customize.
-*/
+/**
+ * Auto-update related functionality.
+ *
+ * By default, all auto-updates are enabled (including major releases).
+ */
 
+/**
+ * Convert string boolean values to actual booleans.
+ *
+ * @param string $value   The value to convert.
+ * @param bool   $default Default value to use if $value is neither 'true' or 'false'.
+ * @return bool The conversion result.
+ */
 function mm_auto_update_make_bool( $value, $default = true ) {
 	if ( 'false' === $value ) {
 		$value = false;
@@ -16,6 +25,11 @@ function mm_auto_update_make_bool( $value, $default = true ) {
 	return $value;
 }
 
+/**
+ * Displays on/off radio buttons for each auto-update type.
+ *
+ * @param array $args
+ */
 function mm_auto_update_callback( $args ) {
 	if ( ! defined( 'AUTOMATIC_UPDATER_DISABLED' ) || AUTOMATIC_UPDATER_DISABLED === false ) {
 		$defaults = array(
@@ -25,16 +39,19 @@ function mm_auto_update_callback( $args ) {
 			'auto_update_theme'             => 'true',
 		);
 		$value    = get_option( $args['field'], $defaults[ $args['field'] ] );
-		echo __( 'On', 'mojo-marketplace-wp-plugin' ) . " <input type='radio' name='" . esc_attr( $args['field'] ) . "' value='true'" . checked( $value, 'true', false ) . ' />';
-		echo __( 'Off', 'mojo-marketplace-wp-plugin' ) . " <input type='radio' name='" . esc_attr( $args['field'] ) . "' value='false'" . checked( $value, 'false', false ) . ' />';
+		echo esc_html__( 'On', 'mojo-marketplace-wp-plugin' ) . " <input type='radio' name='" . esc_attr( $args['field'] ) . "' value='true'" . checked( $value, 'true', false ) . ' />';
+		echo esc_html__( 'Off', 'mojo-marketplace-wp-plugin' ) . " <input type='radio' name='" . esc_attr( $args['field'] ) . "' value='false'" . checked( $value, 'false', false ) . ' />';
 	}
 }
 
+/**
+ * Registers auto-update related settings for the Settings > General page.
+ */
 function mm_auto_update_register_settings() {
 	$section_name = 'mm_auto_update_settings_section';
 	$section_hook = 'general';
 
-	if ( 'bluehost' == mm_brand() ) {
+	if ( 'bluehost' === mm_brand() ) {
 		$brand = __( 'Bluehost', 'mojo-marketplace-wp-plugin' );
 	} else {
 		$brand = __( 'Host', 'mojo-marketplace-wp-plugin' );
@@ -42,7 +59,7 @@ function mm_auto_update_register_settings() {
 
 	if ( ! defined( 'AUTOMATIC_UPDATER_DISABLED' ) ) {
 		$brand = get_option( 'mm_brand', 'MOJO' );
-		if ( 'BlueHost' == $brand ) {
+		if ( 'BlueHost' === $brand ) {
 			$brand = __( 'Bluehost', 'mojo-marketplace-wp-plugin' );
 		}
 		add_settings_section(
@@ -99,6 +116,15 @@ function mm_auto_update_register_settings() {
 }
 add_action( 'admin_init', 'mm_auto_update_register_settings' );
 
+/**
+ * Configures auto-update behaviors for a site.
+ *
+ * If defined, constants override any settings selected on the Settings > General page.
+ *
+ * @since 5.5.0 Translation auto-updates are no longer managed by the plugin. These should always auto-update, which is
+ *              Core's default behavior.
+ * @since 5.5.0 When plugin and theme auto-updates are set to "off", WordPress core will manage
+ */
 function mm_auto_update_configure() {
 	global $wp_version;
 
@@ -167,6 +193,7 @@ function mm_plugin_auto_update_setting_html( $html ) {
 	return str_replace(
 		'<span class="label">Auto-updates enabled</span>',
 		sprintf(
+			/* translators: %s Settings > General page URL. */
 			__( 'Auto-updates enabled on the <a href="%s">Settings > General page</a>.', 'mojo-marketplace-wp-plugin' ),
 			admin_url( 'options-general.php' )
 		),
@@ -192,6 +219,7 @@ function mm_theme_auto_update_setting_html( $html ) {
 	}
 
 	return sprintf(
+		/* translators: %s Settings > General page URL. */
 		__( 'Auto-updates enabled on the <a href="%s">Settings > General page</a>.', 'mojo-marketplace-wp-plugin' ),
 		admin_url( 'options-general.php' )
 	);
@@ -214,7 +242,9 @@ function mm_theme_auto_update_setting_template( $template ) {
 
 	$template_string = '<# } else if ( data.autoupdate.forced ) { #>
 					' . __( 'Auto-updates enabled' );
-	$replacement = '<# } else if ( data.autoupdate.forced ) { #>' . sprintf(
+	$replacement     = '<# } else if ( data.autoupdate.forced ) { #>';
+	$replacement    .= sprintf(
+		/* translators: %s Settings > General page URL. */
 		__( 'Auto-updates enabled on the <a href="%s">Settings > General page</a>.', 'mojo-marketplace-wp-plugin' ),
 		admin_url( 'options-general.php' )
 	);

--- a/package-lock.json
+++ b/package-lock.json
@@ -912,9 +912,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "lodash.merge": {


### PR DESCRIPTION
In summary from #83, the following approach is taken: 

Summary of suggested approach from our standup call today (I am using plugins below, but this is the exact same for themes):
- When a user has auto-updates "on" for plugins, the plugin uses the filter to blanket enable updates. This will cause "Auto-updates enabled" to show unclickable on the Plugins page.
- Filter the "Auto-updates enabled" text to indicate auto-updates are managed by the plugin. Maybe link to the settings page/section.
- On the settings page, add a note next to the setting that explains auto-updates needs to be turned off in order to manually manage which plugins do and do not auto-update. Maybe link to a wordpress.org support page showing how to find/use the new UI.

I did not yet add text to the settings page next to the options. I am not sure what it should say yet. Any suggestions welcome.

Fixes #83.